### PR TITLE
AttributeError: 'NoneType' object has no attribute 'find' when hiding announcement

### DIFF
--- a/announcements/views.py
+++ b/announcements/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponse
 from django.views.generic import list_detail
 from django.shortcuts import get_object_or_404
 
@@ -33,4 +33,7 @@ def announcement_hide(request, object_id):
     excluded_announcements = request.session.get("excluded_announcements", set())
     excluded_announcements.add(announcement.pk)
     request.session["excluded_announcements"] = excluded_announcements
-    return HttpResponseRedirect(redirect_to)
+    if redirect_to:
+        return HttpResponseRedirect(redirect_to)
+    else:
+        return HttpResponse()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/vagrant/env/lib/python2.6/site-packages/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
  File "/home/vagrant/env/lib/python2.6/site-packages/django/core/handlers/wsgi.py", line 241, in __call__
    response = self.get_response(request)
  File "/home/vagrant/env/lib/python2.6/site-packages/django/core/handlers/base.py", line 177, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/home/vagrant/env/lib/python2.6/site-packages/django/core/handlers/base.py", line 219, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/home/vagrant/env/lib/python2.6/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = middleware_method(request, e)
  File "/home/vagrant/env/lib/python2.6/site-packages/django/core/handlers/base.py", line 109, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/vagrant/env/src/django-announcements/announcements/views.py", line 36, in announcement_hide
    return HttpResponseRedirect(redirect_to)
  File "/home/vagrant/env/lib/python2.6/site-packages/django/http/__init__.py", line 747, in __init__
    parsed = urlparse(redirect_to)
  File "/usr/lib/python2.6/urlparse.py", line 108, in urlparse
    tuple = urlsplit(url, scheme, allow_fragments)
  File "/usr/lib/python2.6/urlparse.py", line 147, in urlsplit
    i = url.find(':')
AttributeError: 'NoneType' object has no attribute 'find'
```
